### PR TITLE
Fix out-of-sync issue with forked pyjwt

### DIFF
--- a/trunion/crypto.py
+++ b/trunion/crypto.py
@@ -61,7 +61,8 @@ class KeyStore(object):
 
     def encode_jwt(self, payload):
         header = dict(alg=u'RS256', typ='JWT', jku=self.cert_data['iss'])
-        return jwt.encode(payload, self, header=header)
+        return jwt.encode(payload, self, header=header,
+                          algorithm='RS256')
 
     def decode_jwt(self, payload):
         return jwt.decode(payload, self)


### PR DESCRIPTION
rtilder/pyjwt isn't defaulting to RS256 like the previously included copy
was.  Work around that for the moment.
