### PR TITLE
Add support for the HSMs in production

### DIFF
--- a/etc/trunion.ini
+++ b/etc/trunion.ini
@@ -48,6 +48,7 @@ formatter = generic
 format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
 
 [trunion]
-keyfile = /etc/trunion/test_key.pem
+engine = chil
+keyfile = key-identifier-from-the-HSM
 certfile = /etc/trunion/test_crt.jwk
 permitted_issuers = https://marketplace.mozilla.com

--- a/trunion/__init__.py
+++ b/trunion/__init__.py
@@ -21,7 +21,8 @@ def includeme(config):
 
     crypto.init(key=config.registry.settings['trunion.keyfile'],
                 cert=config.registry.settings['trunion.certfile'],
-                chain=config.registry.settings['trunion.chainfile'])
+                chain=config.registry.settings['trunion.chainfile'],
+                engine=config.registry.settings.get('trunion.engine', None))
 
     issuers = config.registry.settings.get('trunion.permitted_issuers', '')
     issuers = issuers.split(',')


### PR DESCRIPTION
Add basic support for crypto operations in the HSM.

Sadly, I haven't been able to test this yet with a card due to dev HSM hardware availability but the logic for enabling and loading the key from the HSM is straight from a known working script(scripts/certify.py).
