### PR TITLE
Fix for digest mixmatch errors

### DIFF
--- a/trunion/validators.py
+++ b/trunion/validators.py
@@ -174,6 +174,8 @@ def valid_addon(request):
 
     try:
         Signature.parse(request.POST['file'].file.read())
+        # Make certain to reset the file position
+        request.POST['file'].file.seek(0)
     except ParsingError, e:
         raise HTTPBadRequest('Provided XPI signature file does not parse: '
                              '"%s"' % e)

--- a/trunion/validators.py
+++ b/trunion/validators.py
@@ -174,10 +174,11 @@ def valid_addon(request):
 
     try:
         Signature.parse(request.POST['file'].file.read())
-        # Make certain to reset the file position
-        request.POST['file'].file.seek(0)
     except ParsingError, e:
         raise HTTPBadRequest('Provided XPI signature file does not parse: '
                              '"%s"' % e)
+
+    # Make certain to reset the file position
+    request.POST['file'].file.seek(0)
 
     return True


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1130109

Make sure we seek to the beginning of the file-like object in the validator.
Improve the tests to properly test the validator and the validator in use
with the view.
A little bit of flake8 clean up.