### PR TITLE
Use non-greedy matching instead.

### DIFF
--- a/trunion/crypto.py
+++ b/trunion/crypto.py
@@ -14,7 +14,7 @@ import M2Crypto
 import json
 import re
 
-CERTIFICATE_RE = re.compile(r"-----BEGIN CERTIFICATE-----.+"
+CERTIFICATE_RE = re.compile(r"-----BEGIN CERTIFICATE-----.+?"
                             "-----END CERTIFICATE-----", re.S)
 
 # Lame hack to take advantage of a not well known OpenSSL flag.  This omits


### PR DESCRIPTION
Use non-greedy matching so that we can have a chain file with two or more certificates.
r? @rtilder 
